### PR TITLE
Allow Switching To The VC Represented By The Center Button To Be Defeated

### DIFF
--- a/HELargeCenterTabBarController.h
+++ b/HELargeCenterTabBarController.h
@@ -46,6 +46,7 @@ If we need it that someone external needs to delegateness, then we can work that
 */
 @interface HELargeCenterTabBarController : UITabBarController  <UITabBarControllerDelegate>
 
+- (void)addCenterButtonWithUnselectedImage:(UIImage*)unselectedImage selectedImage:(UIImage*)selectedImage target:(id)target action:(SEL)action;
 - (void)addCenterButtonWithUnselectedImage:(UIImage*)unselectedImage selectedImage:(UIImage*)selectedImage target:(id)target action:(SEL)action allowSwitch:(BOOL)allowSwitch;
 
 @property (nonatomic, readonly) UIViewController*       centerViewController;

--- a/HELargeCenterTabBarController.h
+++ b/HELargeCenterTabBarController.h
@@ -46,7 +46,7 @@ If we need it that someone external needs to delegateness, then we can work that
 */
 @interface HELargeCenterTabBarController : UITabBarController  <UITabBarControllerDelegate>
 
-- (void)addCenterButtonWithUnselectedImage:(UIImage*)unselectedImage selectedImage:(UIImage*)selectedImage target:(id)target action:(SEL)action;
+- (void)addCenterButtonWithUnselectedImage:(UIImage*)unselectedImage selectedImage:(UIImage*)selectedImage target:(id)target action:(SEL)action allowSwitch:(BOOL)allowSwitch;
 
 @property (nonatomic, readonly) UIViewController*       centerViewController;
 

--- a/HELargeCenterTabBarController.m
+++ b/HELargeCenterTabBarController.m
@@ -163,8 +163,7 @@
     }
 }
 
-- (BOOL)tabBarController:(UITabBarController *)tabBarController shouldSelectViewController:(UIViewController *)viewController
-{
+- (BOOL)tabBarController:(UITabBarController *)tabBarController shouldSelectViewController:(UIViewController *)viewController {
 	BOOL returnValue = YES;
 
 	if ([self centerViewController] == viewController && NO == self.allowSwitch) {

--- a/HELargeCenterTabBarController.m
+++ b/HELargeCenterTabBarController.m
@@ -43,6 +43,7 @@
 
 @property (nonatomic, strong)   id                  buttonTarget;
 @property (nonatomic, assign)   SEL                 buttonAction;
+@property (nonatomic, assign)	BOOL				allowSwitch;
 
 @end
 
@@ -70,7 +71,7 @@
 //
 // The unselected and selected images are required. target/action is optional, if you want to do something special when the
 // button is selected (generally not needed).
-- (void)addCenterButtonWithUnselectedImage:(UIImage*)unselectedImage selectedImage:(UIImage*)selectedImage target:(id)target action:(SEL)action {
+- (void)addCenterButtonWithUnselectedImage:(UIImage*)unselectedImage selectedImage:(UIImage*)selectedImage target:(id)target action:(SEL)action allowSwitch:(BOOL)allowSwitch {
     NSParameterAssert(unselectedImage != nil);
     NSParameterAssert(selectedImage != nil);
     NSParameterAssert(self.delegate == self);  // it should already be, but in case someone removes it... don't do that!
@@ -80,6 +81,7 @@
     self.buttonImageSelected = selectedImage;
     self.buttonTarget = target;
     self.buttonAction = action;
+	self.allowSwitch = allowSwitch;
     
     UIButton*   strongCenterButton = self.centerButton;
     if (strongCenterButton) {
@@ -114,8 +116,10 @@
 // Hsoi 2014-07-30 - Private action for the center button. This takes care of ensuring things are right internally and that
 // we can fake out the tab controller internals. Then invoking the user's action, if any.
 - (IBAction)centerButtonAction:(id)sender {
-    self.selectedViewController = self.centerViewController;
-    
+	if (self.allowSwitch) {
+		self.selectedViewController = self.centerViewController;
+	}
+
     if (self.buttonTarget && self.buttonAction) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
@@ -159,6 +163,16 @@
     }
 }
 
+- (BOOL)tabBarController:(UITabBarController *)tabBarController shouldSelectViewController:(UIViewController *)viewController
+{
+	BOOL returnValue = YES;
+
+	if ([self centerViewController] == viewController && NO == self.allowSwitch) {
+		returnValue = NO;
+	}
+
+	return returnValue;
+}
 
 
 #pragma mark - Overrides

--- a/HELargeCenterTabBarController.m
+++ b/HELargeCenterTabBarController.m
@@ -67,6 +67,11 @@
 
 #pragma mark - Center Support
 
+// WWG 2015-09-14 - Convenience method, to maintain API compatability for existing clients when adding the "allowSwitch" parameter. (below)
+- (void)addCenterButtonWithUnselectedImage:(UIImage*)unselectedImage selectedImage:(UIImage*)selectedImage target:(id)target action:(SEL)action {
+	[self addCenterButtonWithUnselectedImage:unselectedImage selectedImage:selectedImage target:target action:action allowSwitch:YES];
+}
+
 // Hsoi 2014-07-30 - main public API for setting up the center button.
 //
 // The unselected and selected images are required. target/action is optional, if you want to do something special when the


### PR DESCRIPTION
Here we add an option for `allowSwitch`, which when YES allows the VC represented by the center of the button of the Tab Bar to be presented when it's tapped. If it's NO, the button will still send its action, but the underlying VC will not be made active. This is so that the button can take some other action instead - Like brining up a modal UI, for example.
