### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Build Status](https://travis-ci.org/HsoiEnterprises/HELargeCenterTabBarController.svg)
-![Cocoapods Compatible](https://img.shields.io/cocoapods/v/HELargeCenterTabBarController.svg)
+![CocoaPods Compatible](https://img.shields.io/cocoapods/v/HELargeCenterTabBarController.svg)
 ![License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)
 ![Platform](https://img.shields.io/badge/platform-iOS-lightgrey.svg)
 
@@ -31,14 +31,14 @@ Simple. Lightweight. To-the-point.
 
 # Installation
 
-Currently supports being installed by simple source code addition, by git submodule, or by Cocoapods (preferred).
+Currently supports being installed by simple source code addition, by git submodule, or by CocoaPods (preferred).
 
 
 ## Submodule
 
 You can easily obtain git as a submodule, and simply add `HELargeCenterTabBarController.swift` to your project. Off you go!
 
-## Cocoapods
+## CocoaPods
 
 [CocoaPods][CocoaPods] is a dependency manager for Cocoa projects.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
