### PR TITLE
Updating for Xcode 11 and Swift5

### DIFF
--- a/HELargeCenterTabBarController/HELargeCenterTabBarController.swift
+++ b/HELargeCenterTabBarController/HELargeCenterTabBarController.swift
@@ -153,10 +153,10 @@ class HELargeCenterTabBarController: UITabBarController {
                 button.heightAnchor.constraint(equalToConstant: unselectedImage.size.height)
             ])
         } else {
-            view.addConstraint(NSLayoutConstraint(item: button, attribute: NSLayoutAttribute.centerX, relatedBy: NSLayoutRelation.equal, toItem: view, attribute: NSLayoutAttribute.centerX, multiplier: 1.0, constant: 0.0))
-            view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:[button]-0-|", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: ["button": button]));
-            view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:[button(==\(unselectedImage.size.width))]", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: ["button": button]))
-            view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:[button(==\(unselectedImage.size.height))]", options: NSLayoutFormatOptions(rawValue: 0), metrics: nil, views: ["button": button]))
+            view.addConstraint(NSLayoutConstraint(item: button, attribute: NSLayoutConstraint.Attribute.centerX, relatedBy: NSLayoutConstraint.Relation.equal, toItem: view, attribute: NSLayoutConstraint.Attribute.centerX, multiplier: 1.0, constant: 0.0))
+            view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:[button]-0-|", options: NSLayoutConstraint.FormatOptions(rawValue: 0), metrics: nil, views: ["button": button]));
+            view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:[button(==\(unselectedImage.size.width))]", options: NSLayoutConstraint.FormatOptions(rawValue: 0), metrics: nil, views: ["button": button]))
+            view.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:[button(==\(unselectedImage.size.height))]", options: NSLayoutConstraint.FormatOptions(rawValue: 0), metrics: nil, views: ["button": button]))
         }
         
         button.addTarget(self, action: #selector(centerButtonAction(_:)), for: .touchUpInside)
@@ -201,7 +201,7 @@ class HELargeCenterTabBarController: UITabBarController {
         }
         
         if let centerButton = centerButton {
-            centerButton.setBackgroundImage(buttonImage, for: UIControlState())
+            centerButton.setBackgroundImage(buttonImage, for: UIControl.State())
         }
     }
 


### PR DESCRIPTION
- 'NSLayoutAttribute' has been renamed to 'NSLayoutConstraint.Attribute'
- 'NSLayoutFormatOptions' has been renamed to 'NSLayoutConstraint.FormatOptions'
- 'NSLayoutFormatOptions' has been renamed to 'NSLayoutConstraint.FormatOptions'
- 'NSLayoutFormatOptions' has been renamed to 'NSLayoutConstraint.FormatOptions'
- 'NSLayoutRelation' has been renamed to 'NSLayoutConstraint.Relation'
- 'UIControlState' has been renamed to 'UIControl.State'

Thank you for making this OSS. This is my first pull request to OSS. Please let me know if I have any problems.